### PR TITLE
preserve sort order, assuming there is sort field

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,29 @@
 # directus-extension-board-layout
+
 This repository is a layout extension for Directus, that allows you to display items in a Kanban-style layout.
 
 ## Video of the features (only Japanese Sub)
+
 https://user-images.githubusercontent.com/92870471/212604984-0409b1d8-b636-4bcc-973b-d9d0c6269763.mov
 
 ## Installation
+
 `npm install directus-extension-board-layout` on your directus Project Root folder.
 
 or
 
-Place `index.js` in the `${DIRECTUS_PROJECT_ROOT_FOLDER}/extensions/layout/board-layout/`.
+Clone this repo, then run:
+
+- `npm install`
+- `npm run build`.
+- `dist/index.js` is created by the build command
+- place `index.js` in the `${DIRECTUS_PROJECT_ROOT_FOLDER}/extensions/layouts/board-layout/`
 
 ## Usage
-- You must set a field interface to *dropdown* to choose as a Group By option.
+
+- You must set a field interface to _dropdown_ to choose as a Group By option.
+- Your collection must use the optional system field named `sort` (integer)
+  - you need to set your collection to be sorted by the `sort` field
 
 # License
 

--- a/src/components/paginateUnit.vue
+++ b/src/components/paginateUnit.vue
@@ -167,7 +167,7 @@ export default defineComponent({
     function handleDragEnd(event: EndEvent) {
       const id = event.item.dataset["itemId"];
       const newValue = event.to.dataset["group"];
-      const diff = { id, [field.value.field]: newValue };
+      const diff = { id, [field.value.field]: newValue, sort: event.newIndex };
       api.patch(`items/${collectionKey.value}`, [diff]);
     }
 


### PR DESCRIPTION
just a very simple and maybe a little lazy solution to https://github.com/shocota/directus-extension-board-layout/issues/16
it assumes that the collection uses the "sort optional system field" and that the layout is set to be sorted by the  "sort" field